### PR TITLE
Guard for cases were observation measurement is not retrieved

### DIFF
--- a/arpav_ppcv/observations_harvester/arpafvg.py
+++ b/arpav_ppcv/observations_harvester/arpafvg.py
@@ -1,6 +1,7 @@
 import logging
 from typing import (
     Generator,
+    Optional,
     TYPE_CHECKING,
 )
 
@@ -99,7 +100,7 @@ def fetch_station_measurements(
     series_configuration: ObservationSeriesConfiguration,
     observations_base_url: str,
     auth_token: str,
-) -> Generator[tuple[ObservationYearPeriod, dict], None, None]:
+) -> Generator[tuple[Optional[ObservationYearPeriod], Optional[dict]], None, None]:
     measurements_url = f"{observations_base_url}/clima/indicatori/dati"
     headers = {"Authorization": f"Bearer {auth_token}"}
     station_identifier = observation_station.code.split("-")[-1]
@@ -147,7 +148,7 @@ def fetch_station_measurements(
             for raw_measurement in response.json():
                 yield year_period, raw_measurement
     elif aggreg_type == MeasurementAggregationType.MONTHLY:
-        yield None  # ARPA_FVG observation stations do not have monthly data
+        yield (None, None)  # ARPA_FVG observation stations do not have monthly data
     else:
         raise NotImplementedError(
             f"measurement aggregation type {aggreg_type!r} not implemented"

--- a/arpav_ppcv/prefect/flows/observations.py
+++ b/arpav_ppcv/prefect/flows/observations.py
@@ -414,14 +414,15 @@ def harvest_arpafvg_station_measurements(
             _settings.arpafvg_auth_token,
         )
         for year_period, raw_measurement in raw_measurement_gen:
-            harvested_measurements.append(
-                arpafvg_operations.parse_measurement(
-                    raw_measurement,
-                    year_period,
-                    station,
-                    series_configuration.climatic_indicator,
+            if year_period is not None:
+                harvested_measurements.append(
+                    arpafvg_operations.parse_measurement(
+                        raw_measurement,
+                        year_period,
+                        station,
+                        series_configuration.climatic_indicator,
+                    )
                 )
-            )
         return harvested_measurements
 
 


### PR DESCRIPTION
This PR implements fixes a bug in the observation measurements refresh code whereby there was not the possibility of dealing with cases where the observation station does not have data, as is the case for ARPA FVG stations and the monthly aggregation type.

---

- fixes #332