### PR TITLE
Various fixes related to historical coverage time series

### DIFF
--- a/arpav_ppcv/db/forecastcoverages.py
+++ b/arpav_ppcv/db/forecastcoverages.py
@@ -963,7 +963,7 @@ def get_forecast_coverage_data_series(session: sqlmodel.Session, identifier: str
             f"Processing method {raw_processing_method} does not exist"
         )
     return ForecastDataSeries(
-        forecast_coverage=forecast_coverage,
+        coverage=forecast_coverage,
         dataset_type=dataset_type,
         processing_method=processing_method,
         temporal_start=start,

--- a/arpav_ppcv/schemas/static.py
+++ b/arpav_ppcv/schemas/static.py
@@ -579,6 +579,8 @@ class CoverageTimeSeriesProcessingMethod(str, enum.Enum):
     NO_PROCESSING = "no_processing"
     LOESS_SMOOTHING = "loess_smoothing"
     MOVING_AVERAGE_11_YEARS = "moving_average_11_years"
+    MANN_KENDALL_TREND = "mann_kendall_trend"
+    DECADE_AGGREGATION = "decade_aggregation"
 
     @staticmethod
     def get_param_display_name(locale: babel.Locale) -> str:
@@ -599,6 +601,8 @@ class CoverageTimeSeriesProcessingMethod(str, enum.Enum):
             self.NO_PROCESSING.name: _("no processing"),
             self.LOESS_SMOOTHING.name: _("LOESS"),
             self.MOVING_AVERAGE_11_YEARS.name: _("centered 11-year moving average"),
+            self.MANN_KENDALL_TREND: _("Mann-Kendall trend"),
+            self.DECADE_AGGREGATION.name: _("Decade aggregation"),
         }.get(self, self.value)
 
     def get_value_description(self, locale: babel.Locale) -> str:
@@ -610,13 +614,17 @@ class CoverageTimeSeriesProcessingMethod(str, enum.Enum):
             self.MOVING_AVERAGE_11_YEARS.name: _(
                 "centered 11-year moving average description"
             ),
+            self.MANN_KENDALL_TREND: _("Mann-Kendall trend description"),
+            self.DECADE_AGGREGATION.name: _("Decade aggregation description"),
         }.get(self, self.value)
 
     def get_sort_order(self) -> int:
         return {
             self.NO_PROCESSING.name: 0,
-            self.LOESS_SMOOTHING.name: 0,
-            self.MOVING_AVERAGE_11_YEARS.name: 0,
+            self.LOESS_SMOOTHING.name: 1,
+            self.MOVING_AVERAGE_11_YEARS.name: 2,
+            self.MANN_KENDALL_TREND.name: 3,
+            self.DECADE_AGGREGATION.name: 4,
         }.get(self, 0)
 
 

--- a/arpav_ppcv/webapp/api_v2/schemas/timeseries.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/timeseries.py
@@ -31,6 +31,156 @@ class LegacyTimeSeriesTranslations(pydantic.BaseModel):
     parameter_values: typing.Optional[dict[str, dict[str, str]]] = None
 
     @classmethod
+    def from_historical_data_series(cls, series: "dataseries.HistoricalDataSeries"):
+        return cls(
+            # FIXME: get rid of all the StaticCoverageSeriesParameter stuff
+            parameter_names={
+                "series_name": {
+                    LOCALE_EN.language: StaticCoverageSeriesParameter.SERIES_NAME.get_display_name(
+                        LOCALE_EN
+                    ),
+                    LOCALE_IT.language: StaticCoverageSeriesParameter.SERIES_NAME.get_display_name(
+                        LOCALE_IT
+                    ),
+                },
+                "processing_method": {
+                    LOCALE_EN.language: series.processing_method.get_param_display_name(
+                        LOCALE_EN
+                    ),
+                    LOCALE_IT.language: series.processing_method.get_param_display_name(
+                        LOCALE_IT
+                    ),
+                },
+                "coverage_identifier": {
+                    LOCALE_EN.language: StaticCoverageSeriesParameter.COVERAGE_IDENTIFIER.get_display_name(
+                        LOCALE_EN
+                    ),
+                    LOCALE_IT.language: StaticCoverageSeriesParameter.COVERAGE_IDENTIFIER.get_display_name(
+                        LOCALE_IT
+                    ),
+                },
+                "coverage_configuration": {
+                    LOCALE_EN.language: StaticCoverageSeriesParameter.COVERAGE_CONFIGURATION.get_display_name(
+                        LOCALE_EN
+                    ),
+                    LOCALE_IT.language: StaticCoverageSeriesParameter.COVERAGE_CONFIGURATION.get_display_name(
+                        LOCALE_IT
+                    ),
+                },
+                "aggregation_period": {
+                    LOCALE_EN.language: (
+                        series.coverage.configuration.climatic_indicator.aggregation_period.get_param_display_name(
+                            LOCALE_EN
+                        )
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.configuration.climatic_indicator.aggregation_period.get_param_display_name(
+                            LOCALE_IT
+                        )
+                    ),
+                },
+                "climatological_variable": {
+                    LOCALE_EN.language: (
+                        series.coverage.configuration.climatic_indicator.get_display_name(
+                            LOCALE_EN
+                        )
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.configuration.climatic_indicator.get_display_name(
+                            LOCALE_IT
+                        )
+                    ),
+                },
+                "measure": {
+                    LOCALE_EN.language: (
+                        series.coverage.configuration.climatic_indicator.measure_type.get_param_display_name(
+                            LOCALE_EN
+                        )
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.configuration.climatic_indicator.measure_type.get_param_display_name(
+                            LOCALE_IT
+                        )
+                    ),
+                },
+                "year_period": {
+                    LOCALE_EN.language: (
+                        series.coverage.year_period.get_param_display_name(LOCALE_EN)
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.year_period.get_param_display_name(LOCALE_IT)
+                    ),
+                },
+            },
+            parameter_values={
+                "series_name": {
+                    LOCALE_EN.language: (
+                        series.coverage.configuration.climatic_indicator.description_english
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.configuration.climatic_indicator.description_italian
+                    ),
+                },
+                "processing_method": {
+                    LOCALE_EN.language: (
+                        series.processing_method.get_value_display_name(LOCALE_EN)
+                    ),
+                    LOCALE_IT.language: (
+                        series.processing_method.get_value_display_name(LOCALE_IT)
+                    ),
+                },
+                "coverage_identifier": {
+                    LOCALE_EN.language: series.coverage.identifier,
+                    LOCALE_IT.language: series.coverage.identifier,
+                },
+                "coverage_configuration": {
+                    LOCALE_EN.language: series.coverage.configuration.identifier,
+                    LOCALE_IT.language: series.coverage.configuration.identifier,
+                },
+                "aggregation_period": {
+                    LOCALE_EN.language: (
+                        series.coverage.configuration.climatic_indicator.aggregation_period.get_value_display_name(
+                            LOCALE_EN
+                        )
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.configuration.climatic_indicator.aggregation_period.get_value_display_name(
+                            LOCALE_IT
+                        )
+                    ),
+                },
+                "climatological_variable": {
+                    LOCALE_EN.language: (
+                        series.coverage.configuration.climatic_indicator.display_name_english
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.configuration.climatic_indicator.display_name_italian
+                    ),
+                },
+                "measure": {
+                    LOCALE_EN.language: (
+                        series.coverage.configuration.climatic_indicator.measure_type.get_value_display_name(
+                            LOCALE_EN
+                        )
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.configuration.climatic_indicator.measure_type.get_value_display_name(
+                            LOCALE_IT
+                        )
+                    ),
+                },
+                "year_period": {
+                    LOCALE_EN.language: (
+                        series.coverage.year_period.get_value_display_name(LOCALE_EN)
+                    ),
+                    LOCALE_IT.language: (
+                        series.coverage.year_period.get_value_display_name(LOCALE_IT)
+                    ),
+                },
+            },
+        )
+
+    @classmethod
     def from_forecast_data_series(cls, series: "dataseries.ForecastDataSeries"):
         return cls(
             # FIXME: get rid of all the StaticCoverageSeriesParameter stuff
@@ -69,84 +219,72 @@ class LegacyTimeSeriesTranslations(pydantic.BaseModel):
                 },
                 "aggregation_period": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.aggregation_period.get_param_display_name(
+                        series.coverage.configuration.climatic_indicator.aggregation_period.get_param_display_name(
                             LOCALE_EN
                         )
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.aggregation_period.get_param_display_name(
+                        series.coverage.configuration.climatic_indicator.aggregation_period.get_param_display_name(
                             LOCALE_IT
                         )
                     ),
                 },
                 "climatological_model": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.forecast_model.get_display_name(
-                            LOCALE_EN
-                        )
+                        series.coverage.forecast_model.get_display_name(LOCALE_EN)
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.forecast_model.get_display_name(
-                            LOCALE_IT
-                        )
+                        series.coverage.forecast_model.get_display_name(LOCALE_IT)
                     ),
                 },
                 "climatological_variable": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.get_display_name(
+                        series.coverage.configuration.climatic_indicator.get_display_name(
                             LOCALE_EN
                         )
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.get_display_name(
+                        series.coverage.configuration.climatic_indicator.get_display_name(
                             LOCALE_IT
                         )
                     ),
                 },
                 "measure": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.measure_type.get_param_display_name(
+                        series.coverage.configuration.climatic_indicator.measure_type.get_param_display_name(
                             LOCALE_EN
                         )
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.measure_type.get_param_display_name(
+                        series.coverage.configuration.climatic_indicator.measure_type.get_param_display_name(
                             LOCALE_IT
                         )
                     ),
                 },
                 "scenario": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.scenario.get_param_display_name(
-                            LOCALE_EN
-                        )
+                        series.coverage.scenario.get_param_display_name(LOCALE_EN)
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.scenario.get_param_display_name(
-                            LOCALE_IT
-                        )
+                        series.coverage.scenario.get_param_display_name(LOCALE_IT)
                     ),
                 },
                 "year_period": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.year_period.get_param_display_name(
-                            LOCALE_EN
-                        )
+                        series.coverage.year_period.get_param_display_name(LOCALE_EN)
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.year_period.get_param_display_name(
-                            LOCALE_IT
-                        )
+                        series.coverage.year_period.get_param_display_name(LOCALE_IT)
                     ),
                 },
             },
             parameter_values={
                 "series_name": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.description_english
+                        series.coverage.configuration.climatic_indicator.description_english
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.description_italian
+                        series.coverage.configuration.climatic_indicator.description_italian
                     ),
                 },
                 "processing_method": {
@@ -158,75 +296,67 @@ class LegacyTimeSeriesTranslations(pydantic.BaseModel):
                     ),
                 },
                 "coverage_identifier": {
-                    LOCALE_EN.language: series.forecast_coverage.identifier,
-                    LOCALE_IT.language: series.forecast_coverage.identifier,
+                    LOCALE_EN.language: series.coverage.identifier,
+                    LOCALE_IT.language: series.coverage.identifier,
                 },
                 "coverage_configuration": {
-                    LOCALE_EN.language: series.forecast_coverage.configuration.identifier,
-                    LOCALE_IT.language: series.forecast_coverage.configuration.identifier,
+                    LOCALE_EN.language: series.coverage.configuration.identifier,
+                    LOCALE_IT.language: series.coverage.configuration.identifier,
                 },
                 "aggregation_period": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.aggregation_period.get_value_display_name(
+                        series.coverage.configuration.climatic_indicator.aggregation_period.get_value_display_name(
                             LOCALE_EN
                         )
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.aggregation_period.get_value_display_name(
+                        series.coverage.configuration.climatic_indicator.aggregation_period.get_value_display_name(
                             LOCALE_IT
                         )
                     ),
                 },
                 "climatological_model": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.forecast_model.display_name_english
+                        series.coverage.forecast_model.display_name_english
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.forecast_model.display_name_italian
+                        series.coverage.forecast_model.display_name_italian
                     ),
                 },
                 "climatological_variable": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.display_name_english
+                        series.coverage.configuration.climatic_indicator.display_name_english
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.display_name_italian
+                        series.coverage.configuration.climatic_indicator.display_name_italian
                     ),
                 },
                 "measure": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.measure_type.get_value_display_name(
+                        series.coverage.configuration.climatic_indicator.measure_type.get_value_display_name(
                             LOCALE_EN
                         )
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.configuration.climatic_indicator.measure_type.get_value_display_name(
+                        series.coverage.configuration.climatic_indicator.measure_type.get_value_display_name(
                             LOCALE_IT
                         )
                     ),
                 },
                 "scenario": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.scenario.get_value_display_name(
-                            LOCALE_EN
-                        )
+                        series.coverage.scenario.get_value_display_name(LOCALE_EN)
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.scenario.get_value_display_name(
-                            LOCALE_IT
-                        )
+                        series.coverage.scenario.get_value_display_name(LOCALE_IT)
                     ),
                 },
                 "year_period": {
                     LOCALE_EN.language: (
-                        series.forecast_coverage.year_period.get_value_display_name(
-                            LOCALE_EN
-                        )
+                        series.coverage.year_period.get_value_display_name(LOCALE_EN)
                     ),
                     LOCALE_IT.language: (
-                        series.forecast_coverage.year_period.get_value_display_name(
-                            LOCALE_IT
-                        )
+                        series.coverage.year_period.get_value_display_name(LOCALE_IT)
                     ),
                 },
             },
@@ -243,7 +373,7 @@ class LegacyTimeSeriesTranslations(pydantic.BaseModel):
             "processing_method",
             "station",
             "variable",
-            "series_elaboriation",
+            "series_elaboration",
             "derived_series",
         ):
             names[key_name] = {}
@@ -450,7 +580,7 @@ class LegacyTimeSeriesTranslations(pydantic.BaseModel):
 class LegacyTimeSeries(pydantic.BaseModel):
     name: str
     values: list[TimeSeriesItem]
-    info: typing.Optional[dict[str, str | int | float | bool | dict]] = None
+    info: typing.Optional[dict[str, typing.Any]] = None
     translations: typing.Optional[LegacyTimeSeriesTranslations] = None
 
     @classmethod
@@ -464,17 +594,26 @@ class LegacyTimeSeries(pydantic.BaseModel):
                 for timestamp, value in series.data_.to_dict().items()
                 if not math.isnan(value)
             ],
-            info={
-                "processing_method": series.processing_method.value,
-                "station": series.observation_station.name,
-                "variable": series.observation_series_configuration.climatic_indicator.name,
-                "series_elaboration": None,
-                "derived_series": None,
-            },
+            info=series.get_legacy_info(),
             translations=(
                 LegacyTimeSeriesTranslations.from_observation_station_data_series(
                     series
                 )
+            ),
+        )
+
+    @classmethod
+    def from_historical_data_series(cls, series: "dataseries.HistoricalDataSeries"):
+        return cls(
+            name=series.identifier,
+            values=[
+                TimeSeriesItem(datetime=timestamp, value=value)
+                for timestamp, value in series.data_.to_dict().items()
+                if not math.isnan(value)
+            ],
+            info=series.get_legacy_info(),
+            translations=LegacyTimeSeriesTranslations.from_historical_data_series(
+                series
             ),
         )
 
@@ -487,25 +626,7 @@ class LegacyTimeSeries(pydantic.BaseModel):
                 for timestamp, value in series.data_.to_dict().items()
                 if not math.isnan(value)
             ],
-            info={
-                "processing_method": series.processing_method.value,
-                "coverage_identifier": series.forecast_coverage.identifier,
-                "coverage_configuration": (
-                    series.forecast_coverage.configuration.identifier
-                ),
-                "aggregation_period": (
-                    series.forecast_coverage.configuration.climatic_indicator.aggregation_period.value
-                ),
-                "climatological_model": series.forecast_coverage.forecast_model.name,
-                "climatological_variable": (
-                    series.forecast_coverage.configuration.climatic_indicator.name
-                ),
-                "measure": (
-                    series.forecast_coverage.configuration.climatic_indicator.measure_type.value
-                ),
-                "scenario": series.forecast_coverage.scenario.value,
-                "year_period": series.forecast_coverage.year_period.value,
-            },
+            info=series.get_legacy_info(),
             translations=LegacyTimeSeriesTranslations.from_forecast_data_series(series),
         )
 


### PR DESCRIPTION
This PR includes several fixes to the generation of time series of historical data. Particularly relevant is a refactor of the API endpoint for generating these time series, now including some additional query parameters for specifying the start and end period to be applied when calculating the Mann-Kendall test.

Here is a quick plot of historical data, as returned by the web API, rendered via matplotlib inside a jupyter notebook:

![image](https://github.com/user-attachments/assets/7ade6685-9493-4ca2-ba76-f86e26e82981)

Additionally, the resulting data series for the Mann-Kendall line includes these properties:

```python
{
    'coverage_identifier': 'historical-tas-absolute-annual-arpa_v-only_year-all_year',
    'coverage_configuration': 'historical-tas-absolute-annual-arpa_v-only_year',
    'aggregation_period': 'annual',
    'climatological_variable': 'tas',
    'measure': 'absolute',
    'year_period': 'all_year',
    'processing_method': 'mann_kendall_trend',
    'processing_method_info': {
        'start_year': 1992,
        'end_year': 2023,
        'trend': 'increasing',
        'h': True,
        'p': 3.253640496581056e-06,
        'z': 4.654122047568219,
        'tau': 0.5806451612903226,
        's': 288.0,
        'var_s': 3802.6666666666665,
        'slope': 0.05739088383838389,
        'intercept': 12.45464580050505,
        'is_statistically_significant': True
    },
    'location': 'POINT (12.3003 45.5826)'
}
```

---

- fixes #328