### PR TITLE
Added spatialregion table to vector tile server

### DIFF
--- a/docker/martin/config.yaml
+++ b/docker/martin/config.yaml
@@ -21,7 +21,7 @@ postgres:
       properties:
         name: varchar
         code: varchar
-        id: uuid
+        id: int
         active_since: date
         active_until: date
 
@@ -52,3 +52,15 @@ postgres:
         name: varchar
         province_name: varchar
         region_name: varchar
+
+    spatial-regions:
+      schema: public
+      table: spatialregion
+      srid: 4326
+      geometry_column: geom
+      id_column: ~
+      geometry_type: POLYGON
+      properties:
+        id: int
+        name: varchar
+        internal_value: varchar


### PR DESCRIPTION
This PR adds the additional `spatial-regions` vector tile layer to the tile layer server, thus making it available to interested clients.

Here is a sample visualization in QGIS showing `arpa-v`, `arpa-fvg` and `arpa-taa` regions:

![image](https://github.com/user-attachments/assets/8c1f5682-e1da-4ef6-a2f9-99761da0fb0f)

Note that the provided layer also contains combinations of these regions, for example `arpa_vfvg`.

---

- fixes #338