### PR TITLE
Added obs series confs also to anomaly-related datasets

### DIFF
--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/cdds.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/cdds.py
@@ -38,6 +38,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw2"],
             ],
             forecast_model_group=forecast_model_groups["ensemble"],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "cdds-absolute-annual-arpa_v-yearly"
+                ]
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["cdds-anomaly-thirty_year"],
@@ -59,6 +64,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw2"],
             ],
             forecast_model_group=forecast_model_groups["five_models"],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "cdds-absolute-annual-arpa_v-yearly"
+                ]
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["cdds-absolute-annual"],

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/fd.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/fd.py
@@ -38,6 +38,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "fd-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["fd-anomaly-thirty_year"],
@@ -58,6 +63,11 @@ def generate_forecast_coverage_configurations(
             time_windows=[
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
+            ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "fd-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
             ],
         ),
         ForecastCoverageConfigurationCreate(

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/hdds.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/hdds.py
@@ -38,6 +38,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "hdds-absolute-annual-arpa_v-yearly"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["hdds-anomaly-thirty_year"],
@@ -58,6 +63,11 @@ def generate_forecast_coverage_configurations(
             time_windows=[
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
+            ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "hdds-absolute-annual-arpa_v-yearly"
+                ],
             ],
         ),
         ForecastCoverageConfigurationCreate(

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/pr.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/pr.py
@@ -42,6 +42,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "pr-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["pr-anomaly-thirty_year"],
@@ -63,6 +68,11 @@ def generate_forecast_coverage_configurations(
             time_windows=[
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
+            ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "pr-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
             ],
         ),
         ForecastCoverageConfigurationCreate(
@@ -91,6 +101,11 @@ def generate_forecast_coverage_configurations(
             ],
             year_period_group=year_period_groups["all_seasons"],
             forecast_model_group=forecast_model_groups["ensemble"],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "pr-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["pr-anomaly-annual"],
@@ -108,6 +123,11 @@ def generate_forecast_coverage_configurations(
             ],
             year_period_group=year_period_groups["all_seasons"],
             forecast_model_group=forecast_model_groups["five_models"],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "pr-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["pr-absolute-annual"],
@@ -137,7 +157,7 @@ def generate_forecast_coverage_configurations(
             forecast_model_group=forecast_model_groups["ensemble"],
             observation_series_configurations=[
                 observation_series_configuration_ids[
-                    "tas-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                    "pr-absolute-annual-arpa_v:arpa_fvg-seasonal"
                 ],
             ],
         ),
@@ -159,7 +179,7 @@ def generate_forecast_coverage_configurations(
             forecast_model_group=forecast_model_groups["five_models"],
             observation_series_configurations=[
                 observation_series_configuration_ids[
-                    "tas-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                    "pr-absolute-annual-arpa_v:arpa_fvg-seasonal"
                 ],
             ],
         ),
@@ -191,7 +211,7 @@ def generate_forecast_coverage_configurations(
             forecast_model_group=forecast_model_groups["ensemble"],
             observation_series_configurations=[
                 observation_series_configuration_ids[
-                    "tas-absolute-annual-arpa_v:arpa_fvg-yearly"
+                    "pr-absolute-annual-arpa_v:arpa_fvg-yearly"
                 ],
             ],
         ),
@@ -213,7 +233,7 @@ def generate_forecast_coverage_configurations(
             forecast_model_group=forecast_model_groups["five_models"],
             observation_series_configurations=[
                 observation_series_configuration_ids[
-                    "tas-absolute-annual-arpa_v:arpa_fvg-yearly"
+                    "pr-absolute-annual-arpa_v:arpa_fvg-yearly"
                 ],
             ],
         ),

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/snwdays.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/snwdays.py
@@ -38,6 +38,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "snwdays-absolute-annual-arpa_fvg-yearly"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["snwdays-anomaly-thirty_year"],

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/su30.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/su30.py
@@ -38,6 +38,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "su30-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["su30-anomaly-thirty_year"],
@@ -58,6 +63,11 @@ def generate_forecast_coverage_configurations(
             time_windows=[
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
+            ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "su30-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
             ],
         ),
         ForecastCoverageConfigurationCreate(

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/tas.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/tas.py
@@ -42,6 +42,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tas-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tas-anomaly-thirty_year"],
@@ -63,6 +68,11 @@ def generate_forecast_coverage_configurations(
             time_windows=[
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
+            ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tas-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
             ],
         ),
         ForecastCoverageConfigurationCreate(
@@ -91,6 +101,11 @@ def generate_forecast_coverage_configurations(
             ],
             year_period_group=year_period_groups["all_seasons"],
             forecast_model_group=forecast_model_groups["ensemble"],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tas-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tas-anomaly-annual"],
@@ -108,6 +123,11 @@ def generate_forecast_coverage_configurations(
             ],
             year_period_group=year_period_groups["all_seasons"],
             forecast_model_group=forecast_model_groups["five_models"],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tas-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tas-absolute-annual"],

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/tasmax.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/tasmax.py
@@ -40,6 +40,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmax-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tasmax-anomaly-thirty_year"],
@@ -60,6 +65,11 @@ def generate_forecast_coverage_configurations(
             time_windows=[
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
+            ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmax-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
             ],
         ),
         ForecastCoverageConfigurationCreate(

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/tasmin.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/tasmin.py
@@ -40,6 +40,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmin-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tasmin-anomaly-thirty_year"],
@@ -60,6 +65,11 @@ def generate_forecast_coverage_configurations(
             time_windows=[
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
+            ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmin-absolute-annual-arpa_v:arpa_fvg-seasonal"
+                ],
             ],
         ),
         ForecastCoverageConfigurationCreate(

--- a/arpav_cline/bootstrapper/forecast_coverage_configurations/tr.py
+++ b/arpav_cline/bootstrapper/forecast_coverage_configurations/tr.py
@@ -38,6 +38,11 @@ def generate_forecast_coverage_configurations(
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
             ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tr-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
+            ],
         ),
         ForecastCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tr-anomaly-thirty_year"],
@@ -58,6 +63,11 @@ def generate_forecast_coverage_configurations(
             time_windows=[
                 forecast_time_window_ids["tw1"],
                 forecast_time_window_ids["tw2"],
+            ],
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tr-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
             ],
         ),
         ForecastCoverageConfigurationCreate(

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/cdds.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/cdds.py
@@ -33,6 +33,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_diff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "cdds-absolute-annual-arpa_v-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["cdds-absolute-ten_year"],
@@ -47,6 +52,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "cdds-absolute-annual-arpa_v-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["cdds-anomaly-ten_year"],
@@ -61,6 +71,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "cdds-absolute-annual-arpa_v-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["cdds-absolute-thirty_year"],
@@ -70,5 +85,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "cdds-absolute-annual-arpa_v-yearly"
+                ]
+            ],
         ),
     ]

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/fd.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/fd.py
@@ -33,6 +33,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_diff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "fd-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["fd-absolute-ten_year"],
@@ -47,6 +52,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "fd-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["fd-anomaly-ten_year"],
@@ -61,6 +71,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "fd-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["fd-absolute-thirty_year"],
@@ -70,5 +85,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "fd-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ],
+            ],
         ),
     ]

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/hdds.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/hdds.py
@@ -33,6 +33,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_diff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "hdds-absolute-annual-arpa_v-yearly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["hdds-absolute-ten_year"],
@@ -47,6 +52,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "hdds-absolute-annual-arpa_v-yearly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["hdds-anomaly-ten_year"],
@@ -61,6 +71,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "hdds-absolute-annual-arpa_v-yearly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["hdds-absolute-thirty_year"],
@@ -70,5 +85,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "hdds-absolute-annual-arpa_v-yearly"
+                ],
+            ],
         ),
     ]

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/pr.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/pr.py
@@ -59,6 +59,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_pdiff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "pr-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["pr-absolute-ten_year"],
@@ -73,6 +78,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "pr-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["pr-anomaly-ten_year"],
@@ -87,6 +97,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "pr-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ],
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["pr-absolute-thirty_year"],
@@ -96,5 +111,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "pr-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ],
+            ],
         ),
     ]

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/su30.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/su30.py
@@ -33,6 +33,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_diff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "su30-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["su30-absolute-ten_year"],
@@ -47,6 +52,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "su30-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["su30-anomaly-ten_year"],
@@ -61,6 +71,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "su30-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["su30-absolute-thirty_year"],
@@ -70,5 +85,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "su30-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ]
+            ],
         ),
     ]

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/tas.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/tas.py
@@ -59,6 +59,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_diff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tas-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tas-absolute-ten_year"],
@@ -73,6 +78,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tas-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tas-anomaly-ten_year"],
@@ -87,6 +97,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tas-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tas-absolute-thirty_year"],
@@ -96,5 +111,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tas-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
     ]

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/tasmax.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/tasmax.py
@@ -59,6 +59,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_diff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmax-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tasmax-absolute-ten_year"],
@@ -73,6 +78,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmax-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tasmax-anomaly-ten_year"],
@@ -87,6 +97,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmax-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tasmax-absolute-thirty_year"],
@@ -96,5 +111,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmax-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
     ]

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/tasmin.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/tasmin.py
@@ -59,6 +59,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_diff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmin-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tasmin-absolute-ten_year"],
@@ -73,6 +78,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmin-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tasmin-anomaly-ten_year"],
@@ -87,6 +97,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmin-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tasmin-absolute-thirty_year"],
@@ -96,5 +111,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["all_periods"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tasmin-absolute-annual-arpa_v:arpa_fvg-monthly"
+                ]
+            ],
         ),
     ]

--- a/arpav_cline/bootstrapper/historical_coverage_configurations/tr.py
+++ b/arpav_cline/bootstrapper/historical_coverage_configurations/tr.py
@@ -33,6 +33,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_yr/anomalia1yr/{climatic_indicator}_{year_period}_????-????_diff_{reference_period}.nc",
             wms_main_layer_name="{climatic_indicator}_diff",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tr-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tr-absolute-ten_year"],
@@ -47,6 +52,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tr-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tr-anomaly-ten_year"],
@@ -61,6 +71,11 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_10yr/{climatic_indicator}_{decade}_ref{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tr-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ]
+            ],
         ),
         HistoricalCoverageConfigurationCreate(
             climatic_indicator_id=climatic_indicator_ids["tr-absolute-thirty_year"],
@@ -70,5 +85,10 @@ def generate_historical_coverage_configurations(
             year_period_group=year_period_groups["only_year"],
             thredds_url_pattern="cline_30yr/{climatic_indicator}_{reference_period}.nc",
             wms_main_layer_name="{year_period}_avg",
+            observation_series_configurations=[
+                observation_series_configuration_ids[
+                    "tr-absolute-annual-arpa_v:arpa_fvg-yearly"
+                ]
+            ],
         ),
     ]

--- a/arpav_cline/timeseries.py
+++ b/arpav_cline/timeseries.py
@@ -377,13 +377,21 @@ def get_historical_coverage_time_series(
             temporal_range=temporal_range,
         )
     if include_observation_data:
+        # do not gather time series if the related observation series configuration
+        # specifies a different climatic indicator
+        relevant_series_confs = [
+            oscl.observation_series_configuration
+            for oscl in coverage.configuration.observation_series_configuration_links
+            if (
+                coverage.configuration.climatic_indicator.identifier
+                == oscl.observation_series_configuration.climatic_indicator.identifier
+            )
+        ]
+
         observation_series = _get_forecast_coverage_observation_time_series(
             settings=settings,
             session=session,
-            observation_series_configurations=[
-                oscl.observation_series_configuration
-                for oscl in coverage.configuration.observation_series_configuration_links
-            ],
+            observation_series_configurations=relevant_series_confs,
             point_geom=point_geom,
             processing_methods=observation_processing_methods,
             temporal_range=temporal_range,
@@ -464,13 +472,20 @@ def get_forecast_coverage_time_series(
             temporal_range=temporal_range,
         )
     if include_observation_data:
+        # do not gather time series if the related observation series configuration
+        # specifies a different climatic indicator
+        relevant_series_confs = [
+            oscl.observation_series_configuration
+            for oscl in coverage.configuration.observation_series_configuration_links
+            if (
+                coverage.configuration.climatic_indicator.identifier
+                == oscl.observation_series_configuration.climatic_indicator.identifier
+            )
+        ]
         observation_series = _get_forecast_coverage_observation_time_series(
             settings=settings,
             session=session,
-            observation_series_configurations=[
-                oscl.observation_series_configuration
-                for oscl in coverage.configuration.observation_series_configuration_links
-            ],
+            observation_series_configurations=relevant_series_confs,
             point_geom=point_geom,
             processing_methods=observation_processing_methods,
             temporal_range=temporal_range,


### PR DESCRIPTION
This PR adds the necessary configuration to the `bootstrapper` module so that coverages that represent anomalies also get a relationship to an observation series configuration.

Even though anomaly-related datasets are not strictly related to observations, they are matched with an appropriate observation series configuration so that the API may provide a link to the relevant observation stations vector tile layer. For example, this ensures that when the frontend is showing `tas`-related data (regardless of it being for absolute values or anomalies) in the map, it will be given also a URL for loading the vector tile layer that shows observation stations with `tas` measurements. 

---

- fixes #334