### PR TITLE
Harmonized terminology referring to climatological_variable

### DIFF
--- a/arpav_cline/db/historicalcoverages.py
+++ b/arpav_cline/db/historicalcoverages.py
@@ -461,10 +461,10 @@ def legacy_list_historical_coverage_configurations(
                 == conf_param_filter.climatic_indicator.id
             )
         else:
-            if conf_param_filter.historical_variable is not None:
+            if conf_param_filter.climatological_variable is not None:
                 statement = statement.where(
                     ClimaticIndicator.name  # noqa
-                    == conf_param_filter.historical_variable
+                    == conf_param_filter.climatological_variable
                 )
             if conf_param_filter.measure is not None:
                 statement = statement.where(

--- a/arpav_cline/db/legacy.py
+++ b/arpav_cline/db/legacy.py
@@ -36,39 +36,6 @@ logger = logging.getLogger(__name__)
 _FAKE_ID: Final[uuid.UUID] = uuid.UUID("06213c04-6872-4677-a149-a3b84f8da224")
 
 
-def _get_historical_variable_conf_param(
-    all_climatic_indicators: Sequence[climaticindicators.ClimaticIndicator],
-):
-    conf_param = coverages.ConfigurationParameter(
-        id=_FAKE_ID,
-        name="historical_variable",
-        display_name_english="Variable",
-        display_name_italian="Variabile",
-        description_english="Historical variable",
-        description_italian="Variabile historica",
-        allowed_values=[],
-    )
-    seen = set()
-    for indicator in all_climatic_indicators:
-        for historical_cov_conf in indicator.historical_coverage_configurations:
-            if indicator.name not in seen:
-                seen.add(indicator.name)
-                conf_param.allowed_values.append(
-                    coverages.ConfigurationParameterValue(
-                        id=_FAKE_ID,
-                        name=indicator.name,
-                        internal_value=indicator.name,
-                        display_name_english=indicator.display_name_english,
-                        display_name_italian=indicator.display_name_italian,
-                        description_english=indicator.description_english,
-                        description_italian=indicator.description_italian,
-                        sort_order=indicator.sort_order,
-                        configuration_parameter_id=_FAKE_ID,
-                    )
-                )
-    return conf_param
-
-
 def _get_climatological_variable_conf_param(
     all_climatic_indicators: Sequence[climaticindicators.ClimaticIndicator],
 ):
@@ -529,7 +496,6 @@ def legacy_list_configuration_parameters(
         _get_climatological_variable_conf_param(all_climatic_indicators),
         _get_historical_decade_conf_param(),
         _get_historical_reference_period_conf_param(),
-        _get_historical_variable_conf_param(all_climatic_indicators),
         _get_historical_year_period_conf_param(),
         _get_measure_conf_param(all_climatic_indicators),
         _get_scenario_conf_param(),

--- a/arpav_cline/operations.py
+++ b/arpav_cline/operations.py
@@ -178,7 +178,6 @@ def convert_conf_params_filter(
 
     historical_decade = None
     historical_reference_period = None
-    historical_variable = None
     historical_year_period = None
 
     measure = None
@@ -224,8 +223,6 @@ def convert_conf_params_filter(
                     f"Could not parse {param_value!r} as an historical reference "
                     f"period, skipping..."
                 )
-        elif param_name == "historical_variable":
-            historical_variable = param_value
         elif param_name == "historical_year_period":
             try:
                 historical_year_period = static.HistoricalYearPeriod(param_value)
@@ -279,7 +276,6 @@ def convert_conf_params_filter(
         historical_decade=historical_decade,
         historical_reference_period=historical_reference_period,
         historical_year_period=historical_year_period,
-        historical_variable=historical_variable,
         measure=measure,
         scenario=scenario,
         time_window=time_window,

--- a/arpav_cline/schemas/base.py
+++ b/arpav_cline/schemas/base.py
@@ -29,7 +29,6 @@ class CoreConfParamName(enum.Enum):
     ARCHIVE = "archive"
     CLIMATOLOGICAL_MODEL = "climatological_model"
     CLIMATOLOGICAL_VARIABLE = "climatological_variable"
-    HISTORICAL_VARIABLE = "historical_variable"
     HISTORICAL_YEAR_PERIOD = "historical_year_period"
     MEASURE = "measure"
     SCENARIO = "scenario"
@@ -56,21 +55,6 @@ class Season(enum.Enum):
 
 UNCERTAINTY_TIME_SERIES_PATTERN = "**UNCERTAINTY**"
 RELATED_TIME_SERIES_PATTERN = "**RELATED**"
-
-
-class ObservationAggregationType(str, enum.Enum):
-    MONTHLY = "MONTHLY"
-    SEASONAL = "SEASONAL"
-    YEARLY = "YEARLY"
-
-    def get_display_name(self, locale: babel.Locale) -> str:
-        translations = get_translations(locale)
-        _ = translations.gettext
-        return {
-            self.MONTHLY.name: _("monthly"),
-            self.SEASONAL.name: _("seasonal"),
-            self.YEARLY.name: _("yearly"),
-        }[self.name] or self.name
 
 
 class StaticCoverageSeriesParameter(enum.Enum):

--- a/arpav_cline/schemas/coverages.py
+++ b/arpav_cline/schemas/coverages.py
@@ -720,12 +720,6 @@ class VariableMenuTreeCombination(TypedDict):
     values: list[ConfigurationParameterValue]
 
 
-class HistoricalVariableMenuTree(TypedDict):
-    historical_variable: ConfigurationParameterValue
-    aggregation_period: ConfigurationParameterValue
-    combinations: dict[str, VariableMenuTreeCombination]
-
-
 class ForecastModelClimaticIndicatorLink(sqlmodel.SQLModel, table=True):
     __table_args__ = (
         sqlalchemy.ForeignKeyConstraint(
@@ -1403,7 +1397,6 @@ class LegacyConfParamFilterValues:
     climatological_variable: Optional[str] = None
     historical_decade: Optional[static.HistoricalDecade] = None
     historical_reference_period: Optional[static.HistoricalDecade] = None
-    historical_variable: Optional[str] = None
     historical_year_period: Optional[static.HistoricalYearPeriod] = None
     measure: Optional[static.MeasureType] = None
     scenario: Optional[static.ForecastScenario] = None

--- a/arpav_cline/schemas/legacy.py
+++ b/arpav_cline/schemas/legacy.py
@@ -41,7 +41,7 @@ def convert_to_uncertainty_type(dataset_type: static.DatasetType) -> Optional[st
     }.get(dataset_type, dataset_type.value)
 
 
-def convert_overview_historical_variable(
+def convert_overview_climatological_variable(
     climatic_indicator: "ClimaticIndicator",
 ) -> str:
     return {

--- a/arpav_cline/webapp/api_v2/schemas/timeseries.py
+++ b/arpav_cline/webapp/api_v2/schemas/timeseries.py
@@ -679,7 +679,7 @@ class LegacyTimeSeries(pydantic.BaseModel):
             "coverage_identifier": series.overview_series.identifier,
             "coverage_configuration": series.overview_series.configuration.identifier,
             "archive": "barometro_climatico",
-            "historical_variable": legacy.convert_overview_historical_variable(
+            "climatological_variable": legacy.convert_overview_climatological_variable(
                 series.overview_series.configuration.climatic_indicator
             ),
         }

--- a/arpav_cline/webapp/frontendutils/schemas.py
+++ b/arpav_cline/webapp/frontendutils/schemas.py
@@ -42,7 +42,7 @@ class HistoricalCoverageNavigationSection:
 
 
 class LegacyForecastVariableCombinations(pydantic.BaseModel):
-    variable: str
+    climatological_variable: str
     aggregation_period: str
     measure: str
     other_parameters: dict[str, list[str]]
@@ -60,7 +60,7 @@ class LegacyForecastVariableCombinations(pydantic.BaseModel):
         if len(section.time_windows) > 0:
             other["time_window"] = [tw.name for tw in section.time_windows]
         return cls(
-            variable=section.climatic_indicator.name,
+            climatological_variable=section.climatic_indicator.name,
             aggregation_period=legacy_schemas.convert_to_aggregation_period(
                 section.climatic_indicator.aggregation_period
             ),
@@ -70,7 +70,7 @@ class LegacyForecastVariableCombinations(pydantic.BaseModel):
 
 
 class LegacyHistoricalVariableCombinations(pydantic.BaseModel):
-    variable: str
+    climatological_variable: str
     aggregation_period: str
     measure: str
     other_parameters: dict[str, list[str]]
@@ -88,7 +88,7 @@ class LegacyHistoricalVariableCombinations(pydantic.BaseModel):
         if len(section.decades) > 0:
             other["decade"] = [d.value for d in section.decades]
         return cls(
-            variable=section.climatic_indicator.name,
+            climatological_variable=section.climatic_indicator.name,
             aggregation_period=legacy_schemas.convert_to_aggregation_period(
                 section.climatic_indicator.aggregation_period
             ),


### PR DESCRIPTION
This PR incresases coherence in the codebase and in the API by always referring to a climatic indicator's name as the `climatological_variable`. 

---

- fixes #353