### PR TITLE
Added dataset_type to dataseries from forecasts, historic and observations

### DIFF
--- a/arpav_cline/schemas/dataseries.py
+++ b/arpav_cline/schemas/dataseries.py
@@ -184,6 +184,7 @@ class ForecastDataSeries:
     def get_legacy_info(self) -> dict:
         return {
             "coverage_identifier": self.coverage.identifier,
+            "dataset_type": self.dataset_type,
             "coverage_configuration": self.coverage.configuration.identifier,
             "aggregation_period": (
                 self.coverage.configuration.climatic_indicator.aggregation_period.value
@@ -203,6 +204,7 @@ class ForecastDataSeries:
 class ObservationStationDataSeries:
     observation_series_configuration: "ObservationSeriesConfiguration"
     observation_station: "ObservationStation"
+    dataset_type: static.DatasetType
     processing_method: static.ObservationTimeSeriesProcessingMethod
     location: shapely.Point
     processing_method_info: Optional[dict] = None
@@ -237,6 +239,7 @@ class ObservationStationDataSeries:
             "aggregation_period": (
                 self.observation_series_configuration.climatic_indicator.aggregation_period.value
             ),
+            "dataset_type": self.dataset_type,
             "climatological_variable": self.observation_series_configuration.climatic_indicator.name,
             "measure": self.observation_series_configuration.climatic_indicator.measure_type.value,
             "measurement_aggregation_type": self.observation_series_configuration.measurement_aggregation_type.value,
@@ -286,6 +289,7 @@ class HistoricalDataSeries:
         info = {
             "coverage_identifier": self.coverage.identifier,
             "coverage_configuration": self.coverage.configuration.identifier,
+            "dataset_type": self.dataset_type,
             "aggregation_period": (
                 self.coverage.configuration.climatic_indicator.aggregation_period.value
             ),

--- a/arpav_cline/schemas/static.py
+++ b/arpav_cline/schemas/static.py
@@ -324,8 +324,9 @@ class HistoricalYearPeriod(str, enum.Enum):
 
 class DatasetType(str, enum.Enum):
     MAIN = "main"
-    LOWER_UNCERTAINTY = "lower_uncertainty"
-    UPPER_UNCERTAINTY = "upper_uncertainty"
+    LOWER_UNCERTAINTY = "forecast_lower_uncertainty"
+    OBSERVATION = "observation"
+    UPPER_UNCERTAINTY = "forecast_upper_uncertainty"
 
     @staticmethod
     def get_param_display_name(locale: babel.Locale) -> str:
@@ -345,6 +346,7 @@ class DatasetType(str, enum.Enum):
         return {
             self.MAIN: _("main"),
             self.LOWER_UNCERTAINTY: _("lower uncertainty"),
+            self.OBSERVATION: _("observation measurement"),
             self.UPPER_UNCERTAINTY: _("upper uncertainty"),
         }.get(self, self.value)
 
@@ -354,14 +356,16 @@ class DatasetType(str, enum.Enum):
         return {
             self.MAIN: _("main description"),
             self.LOWER_UNCERTAINTY: _("lower uncertainty description"),
+            self.OBSERVATION: _("observation measurement description"),
             self.UPPER_UNCERTAINTY: _("upper uncertainty description"),
         }.get(self, self.value)
 
     def get_sort_order(self) -> int:
         return {
-            self.LOWER_UNCERTAINTY: 0,
-            self.MAIN: 1,
-            self.UPPER_UNCERTAINTY: 2,
+            self.OBSERVATION: 0,
+            self.LOWER_UNCERTAINTY: 1,
+            self.MAIN: 2,
+            self.UPPER_UNCERTAINTY: 3,
         }.get(self, 0)
 
 

--- a/arpav_cline/timeseries.py
+++ b/arpav_cline/timeseries.py
@@ -293,6 +293,7 @@ def get_nearby_observation_station_time_series(
     if nearby_station is not None:
         result = dataseries.ObservationStationDataSeries(
             observation_series_configuration=observation_series_configuration,
+            dataset_type=static.DatasetType.OBSERVATION,
             observation_station=nearby_station,
             processing_method=static.ObservationTimeSeriesProcessingMethod.NO_PROCESSING,
             location=location,
@@ -600,6 +601,7 @@ def _get_forecast_coverage_observation_time_series(
                     series = dataseries.ObservationStationDataSeries(
                         observation_series_configuration=observation_series_conf,
                         observation_station=observation_data_series.observation_station,
+                        dataset_type=observation_data_series.dataset_type,
                         processing_method=processing_method,
                         location=point_geom,
                     )

--- a/arpav_cline/webapp/api_v2/routers/coverages.py
+++ b/arpav_cline/webapp/api_v2/routers/coverages.py
@@ -977,7 +977,7 @@ def get_forecast_time_series(
         temporal_range = operations.parse_temporal_range(datetime)
         try:
             (
-                coverage_series,
+                forecast_series,
                 observations_series,
             ) = timeseries.get_forecast_coverage_time_series(
                 settings=settings,
@@ -1000,7 +1000,7 @@ def get_forecast_time_series(
             ) from err
         else:
             series = []
-            for forecast_cov_series in coverage_series:
+            for forecast_cov_series in forecast_series:
                 series.append(
                     LegacyTimeSeries.from_forecast_data_series(forecast_cov_series)
                 )


### PR DESCRIPTION
This PR ensures dataseries from `forecast` and historical` coverages and also those from `observation stations` have the `info.dataset_type` property. Depending on the data series, this property shall have a value of either:

- `main` - This applies to the main data series for a forecast and a historical values dataset
- `forecast_lower_uncertainty` - This applies to the lower uncertainty data series of a forecast dataset
- `forecast_upper_uncertainty` - This applies to the upper uncertainty data series of a forecast dataset
- `observation` - This applies to a data series that contains observation measurements


---

- fixes #354