### PR TITLE
Refactored db coverage listing in order to use common functionality

### DIFF
--- a/arpav_cline/db/forecastcoverages.py
+++ b/arpav_cline/db/forecastcoverages.py
@@ -1171,64 +1171,41 @@ def legacy_list_forecast_coverages(
     limit: int = 20,
     offset: int = 0,
     include_total: bool = False,
-    name_filter: list[str] | None = None,
     conf_param_filter: Optional[LegacyConfParamFilterValues] = None,
 ) -> tuple[list[ForecastCoverageInternal], Optional[int]]:
-    all_cov_confs = legacy_collect_all_forecast_coverage_configurations(
-        session, conf_param_filter=conf_param_filter
+    return list_forecast_coverages(
+        session,
+        climatological_variable_filter=(
+            conf_param_filter.climatological_variable
+            if conf_param_filter is not None
+            else None
+        ),
+        aggregation_period_filter=(
+            conf_param_filter.aggregation_period
+            if conf_param_filter is not None
+            else None
+        ),
+        climatological_model_filter=(
+            conf_param_filter.climatological_model
+            if conf_param_filter is not None
+            else None
+        ),
+        scenario_filter=(
+            conf_param_filter.scenario if conf_param_filter is not None else None
+        ),
+        measure_filter=(
+            conf_param_filter.measure if conf_param_filter is not None else None
+        ),
+        year_period_filter=(
+            conf_param_filter.year_period if conf_param_filter is not None else None
+        ),
+        time_window_filter=(
+            conf_param_filter.time_window if conf_param_filter is not None else None
+        ),
+        limit=limit,
+        offset=offset,
+        include_total=include_total,
     )
-    result = []
-    for cov_conf in all_cov_confs:
-        candidates = generate_forecast_coverages_from_configuration(cov_conf)
-        for cov in candidates:
-            is_eligible = True
-            if conf_param_filter is not None:
-                if (
-                    conf_param_filter.scenario
-                    and cov.scenario != conf_param_filter.scenario
-                ):
-                    logger.debug(
-                        f"\t\tScenario {cov.scenario} different from "
-                        f"filter {conf_param_filter.scenario}"
-                    )
-                    is_eligible = False
-                elif (
-                    conf_param_filter.year_period
-                    and cov.year_period != conf_param_filter.year_period
-                ):
-                    logger.debug(
-                        f"\t\tYear period {cov.year_period} different "
-                        f"from filter {conf_param_filter.year_period}"
-                    )
-                    is_eligible = False
-                elif (
-                    conf_param_filter.climatological_model
-                    and cov.forecast_model.name
-                    != conf_param_filter.climatological_model.name
-                ):
-                    logger.debug(
-                        f"\t\tForecast model {cov.forecast_model.name!r} different "
-                        f"from filter {conf_param_filter.climatological_model.name}"
-                    )
-                    is_eligible = False
-                elif (
-                    conf_param_filter.time_window
-                    and cov.forecast_time_window.name
-                    != conf_param_filter.time_window.name
-                ):
-                    logger.debug(
-                        f"\t\tTime window "
-                        f"{cov.forecast_time_window.name if cov.forecast_time_window else None!r} "
-                        f"different from filter {conf_param_filter.time_window.name}"
-                    )
-                    is_eligible = False
-            if is_eligible:
-                result.append(cov)
-
-    if name_filter is not None:
-        for fragment in name_filter:
-            result = [fc for fc in result if fragment in fc.identifier]
-    return result[offset : offset + limit], len(result) if include_total else None
 
 
 def list_forecast_coverages(

--- a/arpav_cline/db/historicalcoverages.py
+++ b/arpav_cline/db/historicalcoverages.py
@@ -571,19 +571,42 @@ def legacy_list_historical_coverages(
     limit: int = 20,
     offset: int = 0,
     include_total: bool = False,
-    name_filter: list[str] | None = None,
     conf_param_filter: Optional[LegacyConfParamFilterValues] = None,
 ) -> tuple[list[HistoricalCoverageInternal], Optional[int]]:
-    all_cov_confs = legacy_collect_all_historical_coverage_configurations(
-        session, conf_param_filter=conf_param_filter
+    return list_historical_coverages(
+        session,
+        climatological_variable_filter=(
+            conf_param_filter.climatological_variable
+            if conf_param_filter is not None
+            else None
+        ),
+        aggregation_period_filter=(
+            conf_param_filter.aggregation_period
+            if conf_param_filter is not None
+            else None
+        ),
+        measure_filter=(
+            conf_param_filter.measure if conf_param_filter is not None else None
+        ),
+        year_period_filter=(
+            conf_param_filter.historical_year_period
+            if conf_param_filter is not None
+            else None
+        ),
+        reference_period_filter=(
+            conf_param_filter.historical_reference_period
+            if conf_param_filter is not None
+            else None
+        ),
+        decade_filter=(
+            conf_param_filter.historical_decade
+            if conf_param_filter is not None
+            else None
+        ),
+        limit=limit,
+        offset=offset,
+        include_total=include_total,
     )
-    result = []
-    for cov_conf in all_cov_confs:
-        result.extend(generate_historical_coverages_from_configuration(cov_conf))
-    if name_filter is not None:
-        for fragment in name_filter:
-            result = [fc for fc in result if fragment in fc.identifier]
-    return result[offset : offset + limit], len(result) if include_total else None
 
 
 def list_historical_coverages(


### PR DESCRIPTION
This PR refactors (forecast and historical) coverage listing in the `db` package in order to reuse common functionality.

This PR was triggered by #360, which was indeed not a bug, as the example request mentioned in the issue is not relevant because the example request used `year_period:winter` when it should have used `historical _year_period:winter` instead. 

---

- #360