### PR TITLE
Refactored historical time series API operation

### DIFF
--- a/arpav_cline/schemas/dataseries.py
+++ b/arpav_cline/schemas/dataseries.py
@@ -205,7 +205,7 @@ class ObservationStationDataSeries:
     observation_series_configuration: "ObservationSeriesConfiguration"
     observation_station: "ObservationStation"
     dataset_type: static.DatasetType
-    processing_method: static.ObservationTimeSeriesProcessingMethod
+    processing_method: static.HistoricalTimeSeriesProcessingMethod
     location: shapely.Point
     processing_method_info: Optional[dict] = None
     data_: Optional[pd.Series] = None
@@ -245,9 +245,11 @@ class ObservationStationDataSeries:
             "measurement_aggregation_type": self.observation_series_configuration.measurement_aggregation_type.value,
             "processing_method": self.processing_method.value,
             "processing_method_info": self.processing_method_info,
-            "managers": self.observation_series_configuration.station_managers,
+            "manager": self.observation_station.managed_by.name,
             "location": self.location.wkt,
             "station_location": to_shape(self.observation_station.geom).wkt,
+            "station_name": self.observation_station.name,
+            "station_code": self.observation_station.code,
         }
 
 
@@ -255,7 +257,7 @@ class ObservationStationDataSeries:
 class HistoricalDataSeries:
     coverage: "HistoricalCoverageInternal"
     dataset_type: static.DatasetType
-    processing_method: static.CoverageTimeSeriesProcessingMethod
+    processing_method: static.HistoricalTimeSeriesProcessingMethod
     temporal_start: Optional[dt.date]
     temporal_end: Optional[dt.date]
     location: shapely.Point

--- a/arpav_cline/schemas/static.py
+++ b/arpav_cline/schemas/static.py
@@ -632,6 +632,65 @@ class CoverageTimeSeriesProcessingMethod(str, enum.Enum):
         }.get(self, 0)
 
 
+class HistoricalTimeSeriesProcessingMethod(str, enum.Enum):
+    DECADE_AGGREGATION = "decade_aggregation"
+    LOESS_SMOOTHING = "loess_smoothing"
+    MANN_KENDALL_TREND = "mann_kendall_trend"
+    NO_PROCESSING = "no_processing"
+    MOVING_AVERAGE_5_YEARS = "moving_average_5_years"
+    MOVING_AVERAGE_11_YEARS = "moving_average_11_years"
+
+    @staticmethod
+    def get_param_display_name(locale: babel.Locale) -> str:
+        translations = get_translations(locale)
+        _ = translations.gettext
+        return _("observation data processing method")
+
+    @staticmethod
+    def get_param_description(locale: babel.Locale) -> str:
+        translations = get_translations(locale)
+        _ = translations.gettext
+        return _("observation data processing method description")
+
+    def get_value_display_name(self, locale: babel.Locale) -> str:
+        translations = get_translations(locale)
+        _ = translations.gettext
+        return {
+            self.DECADE_AGGREGATION.name: _("Decade aggregation"),
+            self.LOESS_SMOOTHING.name: _("LOESS"),
+            self.MANN_KENDALL_TREND: _("Mann-Kendall trend"),
+            self.MOVING_AVERAGE_5_YEARS.name: _("centered 5-year moving average"),
+            self.MOVING_AVERAGE_11_YEARS.name: _("centered 11-year moving average"),
+            self.NO_PROCESSING.name: _("no processing"),
+        }.get(self, self.value)
+
+    def get_value_description(self, locale: babel.Locale) -> str:
+        translations = get_translations(locale)
+        _ = translations.gettext
+        return {
+            self.DECADE_AGGREGATION.name: _("Decade aggregation description"),
+            self.LOESS_SMOOTHING.name: _("LOESS description"),
+            self.MANN_KENDALL_TREND: _("Mann-Kendall trend description"),
+            self.MOVING_AVERAGE_5_YEARS.name: _(
+                "centered 5-year moving average description"
+            ),
+            self.MOVING_AVERAGE_11_YEARS.name: _(
+                "centered 11-year moving average description"
+            ),
+            self.NO_PROCESSING.name: _("no processing description"),
+        }.get(self, self.value)
+
+    def get_sort_order(self) -> int:
+        return {
+            self.DECADE_AGGREGATION.name: 3,
+            self.LOESS_SMOOTHING.name: 1,
+            self.MANN_KENDALL_TREND.name: 2,
+            self.MOVING_AVERAGE_5_YEARS.name: 1,
+            self.MOVING_AVERAGE_11_YEARS.name: 2,
+            self.NO_PROCESSING.name: 0,
+        }.get(self, 0)
+
+
 class ObservationTimeSeriesProcessingMethod(str, enum.Enum):
     NO_PROCESSING = "no_processing"
     MOVING_AVERAGE_5_YEARS = "moving_average_5_years"

--- a/tests/notebooks/historical-coverages.ipynb
+++ b/tests/notebooks/historical-coverages.ipynb
@@ -142,7 +142,7 @@
     }
    ],
    "source": [
-    "all_series = timeseries.get_historical_coverage_time_series(\n",
+    "all_series = timeseries.get_historical_time_series(\n",
     "    settings=settings,\n",
     "    http_client=client,\n",
     "    coverage=cov1,\n",


### PR DESCRIPTION
This PR refactors the code that generates time series for the historical section. API path operation parameters have been changed and the internal implementation is now simpler, as discussed in #370

---

- fixes #370