### PR TITLE
Fix incorrect mann-kendall param initialization

### DIFF
--- a/arpav_cline/webapp/api_v2/routers/coverages.py
+++ b/arpav_cline/webapp/api_v2/routers/coverages.py
@@ -1065,10 +1065,22 @@ def get_historical_time_series(
             mann_kendall_start, mann_kendall_end = parse_temporal_range(
                 mann_kendall_datetime
             )
-            mann_kendall_params = MannKendallParameters(
-                start_year=mann_kendall_start,
-                end_year=mann_kendall_end,
-            )
+            try:
+                mann_kendall_params = MannKendallParameters(
+                    start_year=(
+                        mann_kendall_start.year
+                        if mann_kendall_start is not None
+                        else None
+                    ),
+                    end_year=(
+                        mann_kendall_end.year if mann_kendall_end is not None else None
+                    ),
+                )
+            except pydantic.ValidationError as err:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=err.errors(include_context=False, include_url=False),
+                ) from err
         try:
             historical_series = timeseries.get_historical_time_series(
                 settings=settings,

--- a/tests/test_schemas_dataseries.py
+++ b/tests/test_schemas_dataseries.py
@@ -1,0 +1,54 @@
+from contextlib import nullcontext
+
+import pydantic
+import pytest
+
+from arpav_cline.schemas import dataseries
+
+
+@pytest.mark.parametrize(
+    "start, end, expected",
+    [
+        pytest.param(
+            None,
+            None,
+            nullcontext(
+                dataseries.MannKendallParameters(start_year=None, end_year=None)
+            ),
+        ),
+        pytest.param(
+            None,
+            1990,
+            nullcontext(
+                dataseries.MannKendallParameters(start_year=None, end_year=1990)
+            ),
+        ),
+        pytest.param(
+            1990,
+            None,
+            nullcontext(
+                dataseries.MannKendallParameters(start_year=1990, end_year=None)
+            ),
+        ),
+        pytest.param(
+            2000,
+            2027,
+            nullcontext(
+                dataseries.MannKendallParameters(start_year=2000, end_year=2027)
+            ),
+        ),
+        pytest.param(
+            2001,
+            2027,
+            pytest.raises(pydantic.ValidationError),
+            id="year span less than 27 years",
+        ),
+    ],
+)
+def test_mann_kendall_parameters_year_span(start, end, expected):
+    with expected as e:
+        result = dataseries.MannKendallParameters(
+            start_year=start,
+            end_year=end,
+        )
+        assert result == e


### PR DESCRIPTION
This PR fixes the double parsing error on the Mann-Kendall parameters which was leading to a server crash.

It also adds some unit tests to verify correct implementation of the Mann-Kendall minimum year span logic

---

- fixes #375