### PR TITLE
Added a nearby radius of 2500m for the historical section

### DIFF
--- a/arpav_cline/config.py
+++ b/arpav_cline/config.py
@@ -120,7 +120,8 @@ class ArpavPpcvSettings(BaseSettings):  # noqa
     palette_num_stops: int = 5
     prefect: PrefectSettings = PrefectSettings()
     vector_tile_server_base_url: str = "http://localhost:5001/vector-tiles"
-    nearest_station_radius_meters: int = 1000
+    nearest_station_radius_meters_forecasts: int = 1000
+    nearest_station_radius_meters_historical: int = 2500
     v2_api_mount_prefix: str = "/api/v2"
     v3_api_mount_prefix: str = "/api/v3"
     log_config_file: Path | None = None

--- a/arpav_cline/timeseries.py
+++ b/arpav_cline/timeseries.py
@@ -497,7 +497,7 @@ def get_historical_time_series(
             session,
             point_geom,
             obs_series_conf,
-            distance_threshold_meters=settings.nearest_station_radius_meters,
+            distance_threshold_meters=settings.nearest_station_radius_meters_historical,
             temporal_range=temporal_range,
         )
         if obs_data_series is not None:
@@ -709,7 +709,7 @@ def _get_forecast_coverage_observation_time_series(
             session,
             point_geom,
             observation_series_conf,
-            distance_threshold_meters=settings.nearest_station_radius_meters,
+            distance_threshold_meters=settings.nearest_station_radius_meters_forecasts,
             temporal_range=temporal_range,
         )
         if observation_data_series is not None:


### PR DESCRIPTION
This PR adds a splits the pre-existing config option for setting the nearby radius for finding stations into two variables, one for the forecast section and another for historical section

---

- fixes #377