### PR TITLE
Restored correct mann-kendall trendline calculation with the x-shift

### DIFF
--- a/arpav_cline/timeseries.py
+++ b/arpav_cline/timeseries.py
@@ -102,7 +102,9 @@ def _generate_mann_kendall_series(
     mk_result = pymannkendall.original_test(mk_df[original_column])
     years = range(mk_start, mk_end + 1)
     mk_df = pd.Series(
-        data=[mk_result.slope * year + mk_result.intercept for year in years],
+        data=[
+            mk_result.slope * (year - mk_start) + mk_result.intercept for year in years
+        ],
         index=[pd.Timestamp(year=year, month=7, day=1) for year in years],
         name=column_name,
     ).to_frame()


### PR DESCRIPTION
This PR fixes the calculation of the Mann-Kendall trendline which had mistakenly been modified by #387.

The calculation of this trendline is intended to have the x-axis shifted in order to make the trendline be drawn closer to the data. As such, instead of the usual $y=m*x+b$, we need to use:

$$y = m * (x - x_min) + b$$

Where $m$ is the calculated slope and $b$ is the y-axis intercept, both calculated with the mann-kendally package.

---

- fixes #384