### PR TITLE
393-errors-when-trying-to-retrieve-time-series-in-historical-section

### DIFF
--- a/arpav_cline/prefect/flows/observations.py
+++ b/arpav_cline/prefect/flows/observations.py
@@ -36,6 +36,7 @@ _db_engine = db.get_engine(_settings)
 @prefect.task(
     retries=_settings.prefect.num_task_retries,
     retry_delay_seconds=_settings.prefect.task_retry_delay_seconds,
+    retry_jitter_factor=0.5,
     tags=[PrefectTaskTag.USES_DB.value],
 )
 def refresh_stations_for_climatic_indicator(
@@ -87,6 +88,7 @@ def refresh_station_variables(
 @prefect.task(
     retries=_settings.prefect.num_task_retries,
     retry_delay_seconds=_settings.prefect.task_retry_delay_seconds,
+    retry_jitter_factor=0.5,
     tags=[
         PrefectTaskTag.USES_DB.value,
         PrefectTaskTag.USES_ARPA_V_REST_API,
@@ -121,6 +123,7 @@ def harvest_arpav_stations(
 @prefect.task(
     retries=_settings.prefect.num_task_retries,
     retry_delay_seconds=_settings.prefect.task_retry_delay_seconds,
+    retry_jitter_factor=0.5,
     tags=[
         PrefectTaskTag.USES_DB.value,
         PrefectTaskTag.USES_ARPA_FVG_REST_API,
@@ -153,6 +156,7 @@ def harvest_arpafvg_stations(
 @prefect.task(
     retries=_settings.prefect.num_task_retries,
     retry_delay_seconds=_settings.prefect.task_retry_delay_seconds,
+    retry_jitter_factor=0.5,
     tags=[PrefectTaskTag.USES_DB.value],
 )
 def find_new_stations(
@@ -351,6 +355,7 @@ def refresh_measurements(
     log_prints=True,
     retries=_settings.prefect.num_task_retries,
     retry_delay_seconds=_settings.prefect.task_retry_delay_seconds,
+    retry_jitter_factor=0.5,
     tags=[PrefectTaskTag.USES_DB.value],
 )
 def save_observation_station_measurements(
@@ -382,6 +387,7 @@ def save_observation_station_measurements(
     log_prints=True,
     retries=_settings.prefect.num_task_retries,
     retry_delay_seconds=_settings.prefect.task_retry_delay_seconds,
+    retry_jitter_factor=0.5,
     tags=[
         PrefectTaskTag.USES_DB.value,
         PrefectTaskTag.USES_ARPA_FVG_REST_API,
@@ -429,6 +435,7 @@ def harvest_arpafvg_station_measurements(
 @prefect.task(
     retries=_settings.prefect.num_task_retries,
     retry_delay_seconds=_settings.prefect.task_retry_delay_seconds,
+    retry_jitter_factor=0.5,
     tags=[
         PrefectTaskTag.USES_DB.value,
         PrefectTaskTag.USES_ARPA_V_REST_API,

--- a/arpav_cline/thredds/ncss.py
+++ b/arpav_cline/thredds/ncss.py
@@ -196,7 +196,7 @@ def _parse_ncss_dataset(
     time_start: dt.datetime | None,
     time_end: dt.datetime | None,
     target_series_name: str | None = None,
-) -> pd.Series:
+) -> Optional[pd.Series]:
     df = pd.read_csv(io.StringIO(raw_data), parse_dates=["time"])
     try:
         col_name = [c for c in df.columns if c.startswith(f"{source_main_ds_name}[")][0]
@@ -224,8 +224,9 @@ def _parse_ncss_dataset(
         if time_end is not None:
             df = df[:time_end]
         logger.debug(f"{df=}")
-        return df[target_series_name]
-        # return df.squeeze()
+        result = df[target_series_name]
+        result.dropna(inplace=True)
+        return result if result.size > 0 else None
 
 
 def _simplify_date(raw_date: str) -> str:

--- a/arpav_cline/timeseries.py
+++ b/arpav_cline/timeseries.py
@@ -490,8 +490,8 @@ def get_historical_time_series(
 ) -> list[dataseries.HistoricalDataSeries | dataseries.ObservationStationDataSeries]:
     """Return a list of historical time series for the input location.
 
-    If there is a nearby observation station, returns station data. Otherwise
-    returns NetCDF coverage data
+    If there is a nearby observation station, returns station data. Otherwise,
+    returns NetCDF coverage data (if any).
     """
     # if the related observation series configuration specifies a different climatic
     # indicator try to retrieve historical data instead
@@ -503,7 +503,6 @@ def get_historical_time_series(
             == oscl.observation_series_configuration.climatic_indicator.identifier
         )
     ]
-
     result = []
     for obs_series_conf in relevant_series_confs:
         obs_data_series = get_nearby_observation_station_time_series(

--- a/arpav_cline/webapp/api_v2/routers/coverages.py
+++ b/arpav_cline/webapp/api_v2/routers/coverages.py
@@ -71,7 +71,10 @@ from ....schemas.static import (
     MeasureType,
 )
 from ....schemas.dataseries import MannKendallParameters
-from ... import dependencies
+from ... import (
+    dependencies,
+    parameters,
+)
 from ..schemas.analytics import TimeSeriesDownloadRequestRead
 from ..schemas.coverages import (
     ForecastCoverageDownloadList,
@@ -1036,10 +1039,10 @@ def get_historical_time_series(
     session: Annotated[Session, Depends(dependencies.get_db_session)],
     settings: Annotated[ArpavPpcvSettings, Depends(dependencies.get_settings)],
     http_client: Annotated[httpx.Client, Depends(dependencies.get_sync_http_client)],
-    coverage_identifier: str,
-    coords: str,
-    datetime: Optional[str] = "../..",
-    mann_kendall_datetime: Optional[str] = None,
+    coverage_identifier: parameters.COVERAGE_IDENTIFIER_PATH_PARAMETER,
+    coords: parameters.COORDS_POINT_QUERY_PARAMETER = parameters.DEFAULT_COORDS_POINT_QUERY_PARAMETER,
+    datetime: parameters.TIME_SERIES_DATETIME_QUERY_PARAMETER = "../..",
+    mann_kendall_datetime: parameters.MANN_KENDALL_DATETIME_QUERY_PARAMETER = None,
     include_moving_average_series: bool = False,
     include_decade_aggregation_series: bool = False,
     include_loess_series: bool = False,
@@ -1058,7 +1061,7 @@ def get_historical_time_series(
     if (
         coverage := db.get_historical_coverage(session, coverage_identifier)
     ) is not None:
-        logger.debug(f"found coverage {coverage.identifier=}")
+        logger.debug(f"found coverage {coverage.identifier!r}")
         temporal_range = operations.parse_temporal_range(datetime)
         mann_kendall_params = None
         if mann_kendall_datetime is not None:

--- a/arpav_cline/webapp/parameters.py
+++ b/arpav_cline/webapp/parameters.py
@@ -1,0 +1,143 @@
+"""Centralized location for API parameters.
+
+This allows easier enforcing of parameter bounds checks, etc.
+"""
+
+from typing import Annotated
+
+from fastapi import (
+    Path,
+    Query,
+)
+from fastapi.openapi.models import Example
+
+COVERAGE_IDENTIFIER_PATH_PARAMETER = Annotated[
+    str,
+    Path(
+        max_length=500,
+        description="Identifier of the coverage to retrieve",
+    ),
+]
+
+COORDS_POINT_QUERY_PARAMETER = Annotated[
+    str,
+    Query(
+        max_length=50,
+        description=(
+            "Coordinates of the point to retrieve, expressed in "
+            "[Well-Known Text notation](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)"
+        ),
+    ),
+]
+
+DEFAULT_COORDS_POINT_QUERY_PARAMETER = "POINT(12.314 45.407)"
+
+MANN_KENDALL_DATETIME_QUERY_PARAMETER = Annotated[
+    str | None,
+    Query(
+        max_length=50,
+        description=(
+            "Optional start and end year for Mann-Kendall test.<br><br>"
+            "The expected format for this parameter is described in the "
+            "[OGC API - EDR standard](https://docs.ogc.org/is/19-086r6/19-086r6.html#req_core_rc-time-response).<br><br>"
+            "In short, if provided, this must be a string of the form `{start}/{end}` "
+            "where `{start}` and `{end}` can "
+            "be either an ISO8601 date or the special string `..` to indicate that "
+            "the respective dataset's `start` or `end` should be used. Partial "
+            "ISO8601 dates are allowed (_e.g._ specifying just the year, as in `2020`, "
+            "or just the year and month, as in `2020-01`). Also note that, if "
+            "provided, the year span between `{start}` and `{end}` must be at least "
+            "27 years"
+        ),
+        examples=["1991/2018", "../2030", "1990/..", "../.."],
+        openapi_examples={
+            "start_and_end": Example(
+                summary="Provide both a start and end date",
+                description=(
+                    "If both start and end are provided, the year span between them "
+                    "must be at least 27 years"
+                ),
+                value="1991/2018",
+            ),
+            "omit_start": Example(
+                summary="Omit start date",
+                description=(
+                    "If the start date is replaced with the special '..' string, the "
+                    "start date used will the same as the underlying data's."
+                ),
+                value=".../2018",
+            ),
+            "omit_end": Example(
+                summary="Omit end date",
+                description=(
+                    "If the end date is replaced with the special '..' string, the "
+                    "end date used will the same as the underlying data's."
+                ),
+                value="2018/...",
+            ),
+            "omit_both": Example(
+                summary="Omit both start and end dates",
+                description=(
+                    "If both the start and end dates are replaced with the special "
+                    "'..' string, then the underlying dataset's temporal bounds will "
+                    "be used. This is equivalent to omitting this parameter altogether."
+                ),
+                value="../...",
+            ),
+        },
+    ),
+]
+
+TIME_SERIES_DATETIME_QUERY_PARAMETER = Annotated[
+    str | None,
+    Query(
+        max_length=50,
+        description=(
+            "Optional start and end year for the time series.<br><br>"
+            "The expected format for this parameter is described in the "
+            "[OGC API - EDR standard](https://docs.ogc.org/is/19-086r6/19-086r6.html#req_core_rc-time-response).<br><br>"
+            "In short, if provided, this must be a string of the form `{start}/{end}` "
+            "where `{start}` and `{end}` can be either an ISO8601 date or the special "
+            "string `..` to indicate that the respective dataset's `start` or `end` "
+            "should be used. Partial ISO8601 dates are allowed (_e.g._ specifying "
+            "just the year, as in `2020`, or just the year and month, as in "
+            "`2020-01`)."
+        ),
+        examples=["1991/2018", "../2030", "1990/..", "../.."],
+        openapi_examples={
+            "start_and_end": Example(
+                summary="Provide both a start and end date",
+                description=(
+                    "If both start and end are provided, they are used as the time "
+                    "series year span"
+                ),
+                value="1991/2018",
+            ),
+            "omit_start": Example(
+                summary="Omit start date",
+                description=(
+                    "If the start date is replaced with the special '..' string, the "
+                    "start date used will the same as the underlying data's."
+                ),
+                value=".../2018",
+            ),
+            "omit_end": Example(
+                summary="Omit end date",
+                description=(
+                    "If the end date is replaced with the special '..' string, the "
+                    "end date used will the same as the underlying data's."
+                ),
+                value="2018/...",
+            ),
+            "omit_both": Example(
+                summary="Omit both start and end dates",
+                description=(
+                    "If both the start and end dates are replaced with the special "
+                    "'..' string, then the underlying dataset's temporal bounds will "
+                    "be used. This is equivalent to omitting this parameter altogether."
+                ),
+                value="../...",
+            ),
+        },
+    ),
+]

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -24,7 +24,6 @@ x-common-env: &common-env
   ARPAV_PPCV__THREDDS_SERVER__BASE_URL: http://thredds:8080/thredds
   ARPAV_PPCV__VECTOR_TILE_SERVER_BASE_URL: http://localhost:8877/vector-tiles
   ARPAV_PPCV__PREFECT__NUM_FLOW_RETRIES: 0
-  ARPAV_PPCV__PREFECT__NUM_TASK_RETRIES: 1
   PREFECT_LOGGING_EXTRA_LOGGERS: arpav_cline
 
 x-common-volumes: &common-volumes

--- a/tests/test_thredds_ncss.py
+++ b/tests/test_thredds_ncss.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import pytest
+
+from arpav_cline.thredds import ncss
+
+
+@pytest.mark.parametrize(
+    "raw_data, expected",
+    [
+        pytest.param(
+            (
+                'time,station,latitude[unit="degrees_north"],longitude[unit="degrees_east"],fake[unit="°C"]\n'
+                "2020-01-25T00:00:00Z,GridPointRequestedAt[46.141N_12.809E],46.141,12.807,NaN\n"
+            ),
+            None,
+        ),
+        pytest.param(
+            (
+                'time,station,latitude[unit="degrees_north"],longitude[unit="degrees_east"],fake[unit="°C"]\n'
+                "2020-01-25T00:00:00Z,GridPointRequestedAt[46.141N_12.809E],46.141,12.807,1.2\n"
+                "2020-02-25T00:00:00Z,GridPointRequestedAt[46.141N_12.809E],46.141,12.807,2.3\n"
+                "2020-03-25T00:00:00Z,GridPointRequestedAt[46.141N_12.809E],46.141,12.807,-34\n"
+            ),
+            pd.Series(
+                data=[1.2, 2.3, -34],
+                index=pd.DatetimeIndex(
+                    data=[
+                        "2020-01-25T00:00:00Z",
+                        "2020-02-25T00:00:00Z",
+                        "2020-03-25T00:00:00Z",
+                    ],
+                    tz="UTC",
+                ),
+                name="parsed_fake",
+            ),
+        ),
+    ],
+)
+def test_parse_ncss_dataset(raw_data, expected):
+    parsed = ncss._parse_ncss_dataset(
+        raw_data,
+        "fake",
+        time_start=None,
+        time_end=None,
+        target_series_name="parsed_fake",
+    )
+    if expected is None:
+        assert parsed == expected
+    else:
+        assert expected.equals(parsed)


### PR DESCRIPTION
This PR makes the parsing of data gotten via the THREDDS NetCDF Subset Service (AKA NCSS) more robust by dropping `nan` values from the respective `pandas.Series` instances. It also modifies the NCSS parsing to return `None` if the whole series becomes empty after removal on nans.

Also included is an initial inclusion of the `parameters.py` module, which is to become a centralized place for the definition of API path and query parameters - this shall help enforce things like the max size of strings and other stuff related to OWASP top 10 checks.


Also note that this fixes the error seen in #393, replacing it with an empty payload of the form:

```json
{
    "series": []
}
```

The reason for returning an empty `series` array in the particular case reported in the issue is that the specified `coords` for the time series generation fall outside of the coverage and there is no nearby observation station that has data related to the requested coverage indicator - this is because the request is asking for the coverage identified by `historical-tas-absolute-thirty_year-arpa_v-all_year_and_seasons-climate_standard_normal_1991_2020-all_year`, which specifies an aggregation period of `thirty_year` and there is no station data with that aggregation period.

---

- fixes #393