### PR TITLE
Do not process mann-kendall series if year span is less than 27

### DIFF
--- a/arpav_cline/exceptions.py
+++ b/arpav_cline/exceptions.py
@@ -2,6 +2,10 @@ class ArpavError(Exception):
     ...
 
 
+class MannKendallInsufficientYearError(ArpavError):
+    ...
+
+
 class InvalidForecastYearPeriodGroupNameError(ArpavError):
     ...
 

--- a/arpav_cline/thredds/ncss.py
+++ b/arpav_cline/thredds/ncss.py
@@ -431,7 +431,7 @@ def query_dataset(
     latitude: float,
     time_start: dt.datetime | None = None,
     time_end: dt.datetime | None = None,
-) -> str:
+) -> str | None:
     """Query THREDDS for the specified variable."""
     if time_start is None or time_end is None:
         temporal_parameters = {
@@ -454,10 +454,10 @@ def query_dataset(
     )
     try:
         response.raise_for_status()
-    except httpx.HTTPError as err:
+    except httpx.HTTPError:
         logger.exception(msg="Could not retrieve data")
         logger.debug(f"upstream NCSS error: {response.content}")
-        raise CoverageDataRetrievalError() from err
+        result = None
     else:
         result = response.text
     return result

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,0 +1,68 @@
+from contextlib import nullcontext
+
+import pytest
+
+from arpav_cline import timeseries
+from arpav_cline.exceptions import MannKendallInsufficientYearError
+from arpav_cline.schemas import static
+
+
+@pytest.mark.parametrize(
+    "position_index, mk_start, mk_end, expected",
+    [
+        pytest.param(
+            slice(0, 30),
+            None,
+            None,
+            nullcontext({"start": 1976, "end": 2005, "m": 0.02695420, "b": 3.36297259}),
+        ),
+        pytest.param(
+            slice(0, 26), None, None, pytest.raises(MannKendallInsufficientYearError)
+        ),
+        pytest.param(
+            slice(0, 30, 3), None, None, pytest.raises(MannKendallInsufficientYearError)
+        ),
+        pytest.param(
+            None,
+            1980,
+            None,
+            nullcontext({"start": 1980, "end": 2017, "m": 0.01902530, "b": 3.54188550}),
+        ),
+        pytest.param(
+            None,
+            None,
+            2010,
+            nullcontext({"start": 1976, "end": 2010, "m": 0.03325679, "b": 3.31048281}),
+        ),
+        pytest.param(
+            None,
+            1980,
+            2010,
+            nullcontext({"start": 1980, "end": 2010, "m": 0.03479485, "b": 3.35392543}),
+        ),
+    ],
+)
+def test_generate_mann_kendall_derived_historical_coverage_series(
+    sample_tas_historical_data_series,
+    position_index,
+    mk_start,
+    mk_end,
+    expected,
+):
+    if position_index is not None:
+        pd_series = sample_tas_historical_data_series.data_.copy(deep=True)
+        sample_tas_historical_data_series.data_ = pd_series.iloc[position_index]
+    with expected as e:
+        result = timeseries.generate_mann_kendall_derived_historical_coverage_series(
+            sample_tas_historical_data_series, start_year=mk_start, end_year=mk_end
+        )
+        print(result)
+        assert (
+            result.processing_method
+            == static.HistoricalTimeSeriesProcessingMethod.MANN_KENDALL_TREND
+        )
+        assert result.location == sample_tas_historical_data_series.location
+        assert result.processing_method_info["start_year"] == e["start"]
+        assert result.processing_method_info["end_year"] == e["end"]
+        assert result.processing_method_info["slope"] == pytest.approx(e["m"])
+        assert result.processing_method_info["intercept"] == pytest.approx(e["b"])


### PR DESCRIPTION
This PR implements checking if the selected Mann-Kendall start and end years result in a series where there are at least 27 years worth of data. If this condition is not met, we issue a warning log and skip the generation of this Mann-Kendall related series

---

- fixes #396