### PR TITLE
Implemented station blacklisting

### DIFF
--- a/arpav_cline/config.py
+++ b/arpav_cline/config.py
@@ -137,6 +137,7 @@ class ArpavPpcvSettings(BaseSettings):  # noqa
     arpav_observations_base_url: str = "https://api.arpa.veneto.it/REST/v1"
     arpafvg_observations_base_url: str = "https://api.meteo.fvg.it"
     arpafvg_auth_token: str = "changeme"
+    observation_stations_blacklist: list[str] = []
 
     @pydantic.model_validator(mode="after")
     def ensure_test_db_dsn(self):

--- a/arpav_cline/prefect/flows/observations.py
+++ b/arpav_cline/prefect/flows/observations.py
@@ -114,6 +114,11 @@ def harvest_arpav_stations(
             client,
             series_configuration,
             observations_base_url=_settings.arpav_observations_base_url,
+            ignore_station_codes=[
+                code.rpartition("-")[-1]
+                for code in _settings.observation_stations_blacklist
+                if code.startswith("arpa_v")
+            ],
         )
         for raw_station in retriever:
             stations.add(arpav_operations.parse_station(raw_station, coord_converter))
@@ -147,6 +152,11 @@ def harvest_arpafvg_stations(
             series_configuration,
             observations_base_url=_settings.arpafvg_observations_base_url,
             auth_token=_settings.arpafvg_auth_token,
+            ignore_station_codes=[
+                code.rpartition("-")[-1]
+                for code in _settings.observation_stations_blacklist
+                if code.startswith("arpa_fvg")
+            ],
         )
         for raw_station in retriever:
             stations.add(arpafvg_operations.parse_station(raw_station))

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -24,6 +24,7 @@ x-common-env: &common-env
   ARPAV_PPCV__THREDDS_SERVER__BASE_URL: http://thredds:8080/thredds
   ARPAV_PPCV__VECTOR_TILE_SERVER_BASE_URL: http://localhost:8877/vector-tiles
   ARPAV_PPCV__PREFECT__NUM_FLOW_RETRIES: 0
+  ARPAV_PPCV__OBSERVATION_STATIONS_BLACKLIST: '["arpa_fvg-302"]'
   PREFECT_LOGGING_EXTRA_LOGGERS: arpav_cline
 
 x-common-volumes: &common-volumes


### PR DESCRIPTION
This PR implements blacklisting observation stations.

The proposed implementation adds a new `observation_stations_blacklist` setting (which can be configured via environment) that takes a list of station codes to ignore when updating both ARPAV and ARPAFVG observation stations. Station codes must be input in the same way as they are stored by the system, _i.e._ following the pattern `<manager>-<code>`.

Example:

```python
observation_stations_blacklist = [
    "arpa_fvg-302",  # ignore ARPA FVG station with code 302 (Trieste Meteo Istituto Nautico)
    "arpa_v-110"  # ignore ARPA V station with code 110 (Cittadella)
]
```

> [!note]
> When specifying this configuration parameter via environment it must be supplied as a JSON array, like this:
> ```shell
> ARPAV_PPCV__OBSERVATION_STATIONS_BLACKLIST='["arpa_fvg-302", "arpa_v-110"]'
> ```

Please note that this PR does not automatically delete a station that is already in the DB - this needs to be done manually via the web UI's `admin` section.

---

- fixes #421