### PR TITLE
Increased default DB pool size and made it configurable

### DIFF
--- a/arpav_cline/config.py
+++ b/arpav_cline/config.py
@@ -109,6 +109,7 @@ class ArpavPpcvSettings(BaseSettings):  # noqa
     db_dsn: pydantic.PostgresDsn = pydantic.PostgresDsn(
         "postgresql://user:password@localhost:5432/arpav_ppcv"
     )
+    db_pool_size: int = 10
     test_db_dsn: Optional[pydantic.PostgresDsn] = None
     verbose_db_logs: bool = False
     contact: ContactSettings = ContactSettings()

--- a/arpav_cline/db/engine.py
+++ b/arpav_cline/db/engine.py
@@ -34,6 +34,7 @@ def get_engine(
             _DB_ENGINE = sqlmodel.create_engine(
                 settings.db_dsn.unicode_string(),
                 echo=True if settings.verbose_db_logs else False,
+                pool_size=settings.db_pool_size,
             )
         result = _DB_ENGINE
     return result

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -16,6 +16,7 @@ x-common-env: &common-env
   ARPAV_PPCV__BIND_PORT: 5001
   ARPAV_PPCV__PUBLIC_URL: http://localhost:8877
   ARPAV_PPCV__DB_DSN: postgresql://arpav:arpavpassword@db:5432/arpav_ppcv
+  ARPAV_PPCV__DB_POOL_SIZE: 10
   ARPAV_PPCV__TEST_DB_DSN: postgresql://arpavtest:arpavtestpassword@test-db:5432/arpav_ppcv_test
   ARPAV_PPCV__SESSION_SECRET_KEY: some-key
   ARPAV_PPCV__ADMIN_USER__USERNAME: admin


### PR DESCRIPTION
This PR increases the default DB pool connection pool size from 5 to 10 and also exposes a new `db_pool_size` configuration variable make it configurable. This can thus be set as an environment variable like this:

```shell
ARPAV_PPCV__DB_POOL_SIZE=<some_number>
```

I have already added this env variable to the staging env, with a value of `30`, which means that it will now be able to use a total of 40 connections (30 of pool size + 10 which is the default overflow value).

More info about the engine pool size (and other configuration parameters can be found at

https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine


---

- fixes #423